### PR TITLE
Sort out indexes for the existing provider relationship database

### DIFF
--- a/src/SFA.DAS.PR.Database/Tables/AccountLegalEntities.sql
+++ b/src/SFA.DAS.PR.Database/Tables/AccountLegalEntities.sql
@@ -1,26 +1,22 @@
 ﻿CREATE TABLE [dbo].[AccountLegalEntities]
 (
     [Id] BIGINT NOT NULL,
-    [PublicHashedId] CHAR(6) NOT NULL, 
+    [PublicHashedId] NVARCHAR(6) NOT NULL, 
     [AccountId] BIGINT NOT NULL, 
     [Name] NVARCHAR(100) NOT NULL, 
     [Created] DATETIME2 NOT NULL,
     [Updated] DATETIME2 NULL,
     [Deleted] DATETIME2 NULL,
     CONSTRAINT [PK_AccountLegalEntities] PRIMARY KEY CLUSTERED ([Id] ASC),
-    CONSTRAINT [FK_AccountLegalEntities_Accounts_AccountId] FOREIGN KEY ([AccountId]) REFERENCES [Accounts] ([Id]),
-    INDEX [IX_AccountLegalEntities_AccountId] NONCLUSTERED ([AccountId] ASC)
+    CONSTRAINT [FK_AccountLegalEntities_Accounts_AccountId] FOREIGN KEY ([AccountId]) REFERENCES [dbo].[Accounts] ([Id])
 )
-
 GO
 
-CREATE NONCLUSTERED INDEX [idx_AccountLegalEntities_Deleted]
-ON [dbo].[AccountLegalEntities] ([Deleted]) 
-INCLUDE ([Name], [PublicHashedId]) WITH (ONLINE = ON)
-
+CREATE UNIQUE INDEX [IX_AccountLegalEntities_PublicHashedId]
+ON [dbo].[AccountLegalEntities] ([PublicHashedId]) 
+INCLUDE ([Id], [AccountId], [Name], [Deleted]);
 GO
 
-CREATE NONCLUSTERED INDEX [Idx_AccountLegalEntities_Hashedid]
-ON [dbo].[Accounts] ([HashedId])
 
-GO
+
+

--- a/src/SFA.DAS.PR.Database/Tables/AccountProviderLegalEntities.sql
+++ b/src/SFA.DAS.PR.Database/Tables/AccountProviderLegalEntities.sql
@@ -5,10 +5,19 @@
     [AccountLegalEntityId] BIGINT NOT NULL,
     [Created] DATETIME2 NOT NULL,
     [Updated] DATETIME2 NULL,
-    CONSTRAINT [PK_AccountProviderLegalEntities] PRIMARY KEY CLUSTERED ([Id] ASC),
-    CONSTRAINT [FK_AccountProviderLegalEntities_AccountProviders_AccountProviderId] FOREIGN KEY ([AccountProviderId]) REFERENCES [AccountProviders] ([Id]),
-    CONSTRAINT [FK_AccountProviderLegalEntities_AccountLegalEntities_AccountLegalEntityId] FOREIGN KEY ([AccountLegalEntityId]) REFERENCES [AccountLegalEntities] ([Id]) ON DELETE CASCADE,
-    CONSTRAINT [UK_AccountProviderLegalEntities_AccountProviderId_AccountLegalEntityId] UNIQUE ([AccountProviderId] ASC, [AccountLegalEntityId] ASC),
-    INDEX [IX_AccountProviderLegalEntities_AccountProviderId] NONCLUSTERED ([AccountProviderId] ASC),
-    INDEX [IX_AccountProviderLegalEntities_AccountLegalEntityId] NONCLUSTERED ([AccountLegalEntityId] ASC)
-)
+    CONSTRAINT [PK_AccountProviderLegalEntities] PRIMARY KEY CLUSTERED ([Id]),
+    CONSTRAINT [FK_AccountProviderLegalEntities_AccountProviders_AccountProviderId] 
+        FOREIGN KEY ([AccountProviderId]) 
+        REFERENCES [AccountProviders] ([Id]),
+    CONSTRAINT [FK_AccountProviderLegalEntities_AccountLegalEntities_AccountLegalEntityId] 
+        FOREIGN KEY ([AccountLegalEntityId]) 
+        REFERENCES [AccountLegalEntities] ([Id]) 
+        ON DELETE CASCADE
+);
+GO
+
+CREATE UNIQUE INDEX [IX_AccountProviderLegalEntities_AccountProviderId_AccountLegalEntityId]
+ON [dbo].[AccountProviderLegalEntities] ([AccountProviderId], [AccountLegalEntityId]) 
+INCLUDE ([Id]);
+GO
+

--- a/src/SFA.DAS.PR.Database/Tables/AccountProviders.sql
+++ b/src/SFA.DAS.PR.Database/Tables/AccountProviders.sql
@@ -6,15 +6,12 @@
     [Created] DATETIME2 NOT NULL,
     CONSTRAINT [PK_AccountProviders] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_AccountProviders_Accounts_AccountId] FOREIGN KEY ([AccountId]) REFERENCES [Accounts] ([Id]),
-    CONSTRAINT [FK_AccountProviders_Providers_ProviderUkprn] FOREIGN KEY ([ProviderUkprn]) REFERENCES [Providers] ([Ukprn]),
-    CONSTRAINT [UK_AccountProviders_AccountId_ProviderUkprn] UNIQUE ([AccountId] ASC, [ProviderUkprn] ASC), 
-    INDEX [IX_AccountProviders_AccountId] NONCLUSTERED ([AccountId] ASC)
-)
-
+    CONSTRAINT [FK_AccountProviders_Providers_ProviderUkprn] FOREIGN KEY ([ProviderUkprn]) REFERENCES [Providers] ([Ukprn])
+);
 GO 
 
-CREATE NONCLUSTERED INDEX [IX_AccountProviders_ProviderUkprn] ON [dbo].[AccountProviders]
-(
-    [ProviderUkprn] ASC
-) INCLUDE([AccountId]) WITH (STATISTICS_NORECOMPUTE = OFF, DROP_EXISTING = OFF, ONLINE = OFF) ON [PRIMARY]
+CREATE UNIQUE INDEX [IXU_AccountProviders_ProviderUkprn_AccountId] 
+ON [dbo].[AccountProviders] ([ProviderUkprn],[AccountId])
+INCLUDE([Id]); 
 GO
+

--- a/src/SFA.DAS.PR.Database/Tables/Accounts.sql
+++ b/src/SFA.DAS.PR.Database/Tables/Accounts.sql
@@ -1,10 +1,16 @@
 ﻿CREATE TABLE [dbo].[Accounts]
 (
     [Id] BIGINT NOT NULL,
-    [HashedId] CHAR(6) NOT NULL,
-    [PublicHashedId] CHAR(6) NOT NULL,
+    [HashedId] NVARCHAR(100) NOT NULL,
+    [PublicHashedId] NVARCHAR(100) NOT NULL,
     [Name] NVARCHAR(100) NOT NULL,
     [Created] DATETIME2 NOT NULL,
     [Updated] DATETIME2 NULL,
     CONSTRAINT [PK_Accounts] PRIMARY KEY CLUSTERED ([Id] ASC)
-)
+);
+GO
+
+CREATE NONCLUSTERED INDEX [IX_Accounts_Hashedid]
+ON [dbo].[Accounts] ([HashedId])
+INCLUDE([Id],[Name]);
+GO

--- a/src/SFA.DAS.PR.Database/Tables/Permissions.sql
+++ b/src/SFA.DAS.PR.Database/Tables/Permissions.sql
@@ -4,15 +4,14 @@
     [AccountProviderLegalEntityId] BIGINT NOT NULL,
     [Operation] SMALLINT NOT NULL,
     CONSTRAINT [PK_Permissions] PRIMARY KEY CLUSTERED ([Id] ASC),
-    CONSTRAINT [FK_Permissions_AccountProviderLegalEntities_AccountProviderLegalEntityId] FOREIGN KEY ([AccountProviderLegalEntityId]) REFERENCES [AccountProviderLegalEntities] ([Id]) ON DELETE CASCADE,
-    CONSTRAINT [UK_Permissions_AccountProviderLegalEntityId_Operation] UNIQUE ([AccountProviderLegalEntityId] ASC, [Operation] ASC),
-    INDEX [IX_Permissions_AccountProviderLegalEntityId] NONCLUSTERED ([AccountProviderLegalEntityId] ASC)
-)
-
+    CONSTRAINT [FK_Permissions_AccountProviderLegalEntities_AccountProviderLegalEntityId] 
+    FOREIGN KEY ([AccountProviderLegalEntityId]) 
+    REFERENCES [AccountProviderLegalEntities] ([Id]) ON DELETE CASCADE
+);
 GO 
 
-CREATE NONCLUSTERED INDEX [idx_Permissions_Operation] 
-ON [dbo].[Permissions] ([Operation]) 
-INCLUDE ([AccountProviderLegalEntityId]) WITH (ONLINE = ON)
-
+CREATE UNIQUE INDEX [IX_Permissions_AccountProviderLegalEntityId_Operation] 
+ON [dbo].[Permissions] ([AccountProviderLegalEntityId] ASC,[Operation] ASC);
 GO
+
+


### PR DESCRIPTION
Also includes alignment of data fields to the same field types and sizes found in Employer Accounts.
Deploys without issue on pre-existing PR database with contents. 